### PR TITLE
Replace arrow notation with es5 standard function mapping to allow fo…

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,10 +26,11 @@ module.exports = function fetchCookieDecorator (fetch, jar) {
           return res
         }
 
-        return Promise.all(cookies.map(cookie => setCookie(cookie, url)))
-          .then(function () {
-            return res
-          })
-      })
+        return Promise.all(cookies.map(function(cookie){
+          return setCookie(cookie,url);
+        })).then(function () {
+          return res
+        });
+      });
   }
 }


### PR DESCRIPTION
Replace arrow notation with es5 standard function mapping to allow for wider compatibility;

On older Node environments arrow functions are not supported and cannot be polyfilled.  