### PR TITLE
Use final URL (i.e. URL after redirects) when storing cookies.

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ module.exports = function fetchCookieDecorator (fetch, jar) {
         }
 
         return Promise.all(cookies.map(function (cookie) {
-          return setCookie(cookie, url)
+          return setCookie(cookie, res.url)
         })).then(function () {
           return res
         })


### PR DESCRIPTION
fixes #7 