### PR TITLE
apply cookie header only when there are cookies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /node_modules
+.idea

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ module.exports = function fetchCookieDecorator (fetch, jar) {
     return getCookieString(url)
       .then(function (cookie) {
         return fetch(url, Object.assign(opts, {
-          headers: Object.assign(opts.headers || {}, { cookie: cookie })
+          headers: Object.assign(opts.headers || {}, (cookie ? { cookie: cookie } : {}))
         }))
       })
       .then(function (res) {


### PR DESCRIPTION
I had problems calling a web service that behaved strangely when a empty cookie header was sent. Changed that behaviour to avoid such problem. Should not break any functionality of existing use-cases. Would be glad if that gets accepted.