### PR TITLE
Set minimum version of tough-cookie to 2.3.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "es6-denodeify": "^0.1.1",
-    "tough-cookie": "^2.3.1"
+    "tough-cookie": "^2.3.3"
   },
   "devDependencies": {
     "@types/chai": "^4.1.4",

--- a/test/test.js
+++ b/test/test.js
@@ -56,8 +56,14 @@ describe('fetch-cookie', () => {
     // Compare the two clients (jars)
     assert.notEqual(cookie1, cookie2)
     assert.notStrictEqual(cookie1.key, cookie2.key)
-    assert.notProperty(cookies1, cookie2)
-    assert.notProperty(cookies2, cookie1)
+
+    Object.keys(cookies1).forEach(cookie1Key => {
+      assert.notProperty(cookie2, cookie1Key)
+    })
+
+    Object.keys(cookies2).forEach(cookie2Key => {
+      assert.notProperty(cookie1, cookie2Key)
+    })
   })
 
   // TODO: Remove this test once node-fetch v1 is not supported anymore


### PR DESCRIPTION
Modify `package.json` to ensure the minimum version of tough-cookie is 2.3.3.

v2.3.3 includes salesforce/tough-cookie#97 which addresses a ReDOS vulnerability.

Also modified `test.js` because the use of [`notProperty`](https://www.chaijs.com/api/assert/#method_notproperty) seemed incorrect and tests were failing - see #36.

cc @FabianTe 