### PR TITLE
Handle request object correctly

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ module.exports = function fetchCookieDecorator (fetch, jar) {
     opts = opts || {}
 
     // Prepare request
-    const cookie = await getCookieString(url)
+    const cookie = await getCookieString(typeof url === 'string' ? url : url.url)
 
     if (url.headers && typeof url.headers.append === 'function') {
       url.headers.append('cookie', cookie)


### PR DESCRIPTION
Properly fixes #28.

Before this change this module wasn't able to properly retrieve the cookie string which resulted in it setting an empty one instead.

The naming looks quite confusing now (`url.url`), it might be a good idea to rename the parameters ([you might take inspiration from TypeScript](https://github.com/microsoft/TypeScript/blob/master/lib/lib.dom.d.ts#L19944)), though that's not my call to make.