### PR TITLE
Support more versions of tough-cookie, use util.promisify

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,12 +1,12 @@
-var denodeify = require('es6-denodeify')(Promise)
-var tough = require('tough-cookie')
+const { promisify } = require('util')
+const tough = require('tough-cookie')
 
 module.exports = function fetchCookieDecorator (fetch, jar) {
   fetch = fetch || window.fetch
   jar = jar || new tough.CookieJar()
 
-  var getCookieString = denodeify(jar.getCookieString.bind(jar))
-  var setCookie = denodeify(jar.setCookie.bind(jar))
+  var getCookieString = promisify(jar.getCookieString.bind(jar))
+  var setCookie = promisify(jar.setCookie.bind(jar))
 
   async function fetchCookie (url, opts) {
     opts = opts || {}

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test": "mocha"
   },
   "dependencies": {
-    "tough-cookie": "^3.0.1 || ^4.0.0"
+    "tough-cookie": "^2.3.3 || ^3.0.1 || ^4.0.0"
   },
   "devDependencies": {
     "@types/chai": "^4.1.4",
@@ -40,6 +40,6 @@
     "mocha": "^7.1.1",
     "node-fetch": "^2.6.0",
     "standard": "^14.3.3",
-    "tough-cookie": "^3.0.1 || ^4.0.0"
+    "tough-cookie": "^2.3.3 || ^3.0.1 || ^4.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,10 +1,13 @@
 {
   "name": "fetch-cookie",
-  "version": "0.7.3",
+  "version": "0.8.0",
   "description": "Decorator for a `fetch` function to support automatic cookies.",
   "homepage": "https://github.com/valeriangalliat/fetch-cookie",
   "bugs": "https://github.com/valeriangalliat/fetch-cookie/issues",
   "license": "Unlicense",
+  "engines": {
+    "node": ">=8"
+  },
   "author": {
     "name": "Valérian Galliat",
     "url": "http://val.codejam.info/"
@@ -25,18 +28,18 @@
     "test": "mocha"
   },
   "dependencies": {
-    "es6-denodeify": "^0.1.1",
-    "tough-cookie": "^2.3.3"
+    "tough-cookie": "^3.0.1 || ^4.0.0"
   },
   "devDependencies": {
     "@types/chai": "^4.1.4",
     "@types/express": "^4.16.0",
-    "@types/mocha": "^5.2.5",
+    "@types/mocha": "^7.0.2",
     "@types/node-fetch": "^2.1.1",
     "chai": "^4.1.2",
     "express": "^4.14.1",
-    "mocha": "^3.2.0",
-    "node-fetch": "^1.6.3",
-    "standard": "^11.0.1"
+    "mocha": "^7.1.1",
+    "node-fetch": "^2.6.0",
+    "standard": "^14.3.3",
+    "tough-cookie": "^3.0.1 || ^4.0.0"
   }
 }


### PR DESCRIPTION
I was having trouble with what I believe was a mismatch in `tough-cookie` versions, so decided to try my hand at addling larger support range

If the `node@8` requirement is an issue, could inline a promisify function

Changes:
1. Drop `es6-denodeify` in favour of `util.promisify`
1. Expand version range for tough cookie
1. Update other dependencies
1. Require node@8 (for promisify)

Scoped publish to test
```
npm i @qw-in/fetch-cookie
```