### PR TITLE
feat: allow errors from setCookie to be ignored

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,22 @@ esentially two different HTTP clients with different login sessions on you backe
 
 All calls to `fetch` will store and send back cookies according to the URL.
 
+> Note: All errors when setting cookies are ignored by default. You can make it to throw errors in cookies by passing a third argument (default is true).
+
+```js
+const nodeFetch = require('node-fetch')
+const tough = require('tough-cookie')
+const fetch = require('fetch-cookie')(nodeFetch, new tough.CookieJar(), false) // default value is true
+// false - doesn't ignore errors, throws when an error occurs in setting cookies and breaks the request and execution
+// true - silently ignores errors and continues to make requests/redirections
+```
+
 If you use a cookie jar that is not tough-cookie, keep in mind that it must implement this interface to be compatible:
 
 ```ts
 interface CookieJar {
   getCookieString(currentUrl: string, cb: (err: any, cookies: string) => void): void;
-  setCookie(cookieString: string, currentUrl: string, cb: (err: any) => void): void;
+  setCookie(cookieString: string, currentUrl: string, cb: (err: any) => void, opts: { ignoreError:boolean }): void;
 }
 ```
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,10 +1,10 @@
 declare namespace c {
   interface CookieJar {
     getCookieString(currentUrl: string, cb: (err: any, cookies: string) => void): void;
-    setCookie(cookieString: string, currentUrl: string, cb: (err: any) => void): void;
+    setCookie(cookieString: string, currentUrl: string, cb: (err: any) => void, opts: { ignoreError: boolean }): void;
   }
 }
 
-declare function c(fetch: Function, jar?: c.CookieJar): Function;
+declare function c(fetch: Function, jar?: c.CookieJar, ignoreError: boolean): Function;
 
 export = c;

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 const { promisify } = require('util')
 const tough = require('tough-cookie')
 
-module.exports = function fetchCookieDecorator (fetch, jar) {
+module.exports = function fetchCookieDecorator (fetch, jar, ignoreError = true) {
   fetch = fetch || window.fetch
   jar = jar || new tough.CookieJar()
 
@@ -45,7 +45,7 @@ module.exports = function fetchCookieDecorator (fetch, jar) {
     }
 
     // Store all present cookies
-    await Promise.all(cookies.map((cookie) => setCookie(cookie, res.url)))
+    await Promise.all(cookies.map((cookie) => setCookie(cookie, res.url, { ignoreError })))
 
     return res
   }

--- a/node-fetch.d.ts
+++ b/node-fetch.d.ts
@@ -1,5 +1,5 @@
 import { CookieJar } from './';
 
-declare function c(fetch: Function, jar?: CookieJar): Function;
+declare function c(fetch: Function, jar?: CookieJar, ignoreError: boolean): Function;
 
 export = c;

--- a/test/test-server.js
+++ b/test/test-server.js
@@ -30,4 +30,13 @@ app.get('/redirect', (req, res) => {
   res.redirect('http://localhost:9998/get') // FIXME: There is nothing at this port ...
 })
 
+app.get('/cookie', (req, res) => {
+  res.setHeader(
+    'set-cookie',
+    'my_cookie=HelloWorld; path=/; domain=www.example.com; secure; HttpOnly; SameSite=Lax'
+  );
+  res.cookie('tuna', 'can');
+  res.end()
+});
+
 module.exports = app

--- a/test/test.js
+++ b/test/test.js
@@ -108,6 +108,30 @@ describe('fetch-cookie', () => {
     assert.notStrictEqual(cookie1.key, cookie2.key)
   })
 
+  it("should ignore error when there is error in setCookie", async () => {
+    const jar = new CookieJar();
+    const fetch = require('../index')(nodeFetch, jar);
+    let error = null;
+    try {
+      await fetch('http://localhost:9999/cookie');
+    } catch (err) {
+      error = err;
+    }
+    assert.isNull(error);
+  });
+
+  it('should throw error when there is error in setCookie', async () => {
+    const jar = new CookieJar();
+    const fetch = require('../index')(nodeFetch, jar, false);
+    let error = null;
+    try {
+      await fetch('http://localhost:9999/cookie');
+    } catch (err) {
+      error = err;
+    }
+    assert.instanceOf(error, Error)
+  });
+
   after('stop test server', () => {
     if (server) { server.close() }
   })


### PR DESCRIPTION
Refer this: request/request#794

This is an error from tough cookie and they allow us to ignore errors. Sometimes we don't wanna stop the request when there is an error in cookie setting.

So, now we can allow user to ignore or raise error in setCookie. This will be helpful as most of the people use this package to fetch body from a request and we don't want to end up with an error when there is something wrong in setCookie.

This closes #41 and #52 