### PR TITLE
Fix set-cookie typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 declare namespace c {
   interface CookieJar {
     getCookieString(currentUrl: string, cb: (err: any, cookies: string) => void): void;
-    setCookie(cookieString: string, currentUrl: string, cb: (err: any) => void, opts: { ignoreError: boolean }): void;
+    setCookie(cookieString: string, currentUrl: string, opts: { ignoreError: boolean }, cb: (err: any) => void): void;
   }
 }
 


### PR DESCRIPTION
Set cookie is promisified in code which requires the last arg to be the callback arg. This change updates the typing such that the typings now have the callback as the final arg.