### PR TITLE
Fix empty cookie header

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,4 @@
-on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
-
+on: [push, pull_request]
 jobs:
   build:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x, 14.x, 15.x]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm ci
+    - run: npm run build --if-present
+    - run: npm test

--- a/index.js
+++ b/index.js
@@ -15,9 +15,9 @@ module.exports = function fetchCookieDecorator (fetch, jar, ignoreError = true) 
     const cookie = await getCookieString(typeof url === 'string' ? url : url.url)
 
     if (url.headers && typeof url.headers.append === 'function') {
-      url.headers.append('cookie', cookie)
+      cookie && url.headers.append('cookie', cookie)
     } else if (opts.headers && typeof opts.headers.append === 'function') {
-      opts.headers.append('cookie', cookie)
+      cookie && opts.headers.append('cookie', cookie)
     } else {
       opts.headers = Object.assign(
         opts.headers || {},

--- a/test/test-server.js
+++ b/test/test-server.js
@@ -26,6 +26,12 @@ app.get('/get', (req, res) => {
   res.json(cookies)
 })
 
+app.get('/ok-if-empty', (req, res) => {
+  // Get cookies
+  let response = req.headers.cookie === undefined  ? {"status": "ok"} : {"status": "not-ok"}
+  res.json(response)
+})
+
 app.get('/redirect', (req, res) => {
   res.redirect('http://localhost:9998/get') // FIXME: There is nothing at this port ...
 })

--- a/test/test-server.js
+++ b/test/test-server.js
@@ -28,7 +28,7 @@ app.get('/get', (req, res) => {
 
 app.get('/ok-if-empty', (req, res) => {
   // Get cookies
-  let response = req.headers.cookie === undefined  ? {"status": "ok"} : {"status": "not-ok"}
+  const response = { status: req.headers.cookie === undefined ? 'ok' : 'not-ok' }
   res.json(response)
 })
 

--- a/test/test.js
+++ b/test/test.js
@@ -23,6 +23,13 @@ describe('fetch-cookie', () => {
     assert.propertyVal(res, 'status', 200)
   })
 
+  it('should not send empty cookie header', async () => {
+    const req = new nodeFetch.Request('http://localhost:9999/ok-if-empty')
+    const res = await fetch(req)
+
+    assert.deepEqual(await res.json(), {"status": "ok"})
+  })
+
   it('should handle cookies (using internal cookie jar)', async () => {
     await fetch('http://localhost:9999/set?name=foo&value=bar')
     const res = await fetch('http://localhost:9999/get')

--- a/test/test.js
+++ b/test/test.js
@@ -27,7 +27,7 @@ describe('fetch-cookie', () => {
     const req = new nodeFetch.Request('http://localhost:9999/ok-if-empty')
     const res = await fetch(req)
 
-    assert.deepEqual(await res.json(), {"status": "ok"})
+    assert.deepEqual(await res.json(), { status: 'ok' })
   })
 
   it('should handle cookies (using internal cookie jar)', async () => {


### PR DESCRIPTION
Hello @valeriangalliat 
A project that I use utilize your package to send requests, and some very picky servers are giving me problems.

After some investigations, it appears that when no cookie is specified the Cookie header is still created and sent empty in the form `cookie: ''`. According to https://tools.ietf.org/html/rfc6265#section-5.4 and https://datatracker.ietf.org/doc/html/rfc6265#section-4.2.1 this should not be the case, and in fact some servers returns error 400 BAD_REQUEST.

This PR aims to fix this.

Please let me know what you think, and thank you.