### PR TITLE
Make interface CookieJar exported

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -44,7 +44,7 @@ type NodeFetchHeaders = Headers & {
   raw?: () => { [name: string]: string[] }
 }
 
-interface CookieJar {
+export interface CookieJar {
   getCookieString: (currentUrl: string) => Promise<string>
   setCookie: (cookieString: string, currentUrl: string, opts: { ignoreError: boolean }) => Promise<any>
 }


### PR DESCRIPTION
I need a type of CookieJar in my app, it is impossible for me to get it unless it's exported